### PR TITLE
add noise_model to override in run method

### DIFF
--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -229,7 +229,8 @@ def qiskit_circ_to_ionq_circ(input_circuit, gateset="qis"):
                     for i in range(instruction.num_ctrl_qubits)
                 ]
                 targets = [
-                    input_circuit.qubits.index(qargs[instruction.num_ctrl_qubits])
+                    input_circuit.qubits.index(
+                        qargs[instruction.num_ctrl_qubits])
                 ]
             if gate == "swap":
                 # If this is a cswap, we have two targets:
@@ -353,7 +354,8 @@ def qiskit_to_ionq(circuit, backend, passed_args=None):
         str: A string / JSON-serialized dictionary with IonQ API compatible values.
     """
     passed_args = passed_args or {}
-    ionq_circ, _, meas_map = qiskit_circ_to_ionq_circ(circuit, backend.gateset())
+    ionq_circ, _, meas_map = qiskit_circ_to_ionq_circ(
+        circuit, backend.gateset())
     creg_sizes, clbit_labels = get_register_sizes_and_labels(circuit.cregs)
     qreg_sizes, qubit_labels = get_register_sizes_and_labels(circuit.qregs)
     qiskit_header = compress_dict_to_metadata_string(
@@ -362,10 +364,14 @@ def qiskit_to_ionq(circuit, backend, passed_args=None):
             "global_phase": circuit.global_phase,  # float
             "n_qubits": circuit.num_qubits,  # int
             "name": circuit.name,  # str
-            "creg_sizes": creg_sizes,  # list of [str, int] tuples cardinality memory_slots
-            "clbit_labels": clbit_labels,  # list of [str, int] tuples cardinality memory_slots
-            "qreg_sizes": qreg_sizes,  # list of [str, int] tuples cardinality num_qubits
-            "qubit_labels": qubit_labels,  # list of [str, int] tuples cardinality num_qubits
+            # list of [str, int] tuples cardinality memory_slots
+            "creg_sizes": creg_sizes,
+            # list of [str, int] tuples cardinality memory_slots
+            "clbit_labels": clbit_labels,
+            # list of [str, int] tuples cardinality num_qubits
+            "qreg_sizes": qreg_sizes,
+            # list of [str, int] tuples cardinality num_qubits
+            "qubit_labels": qubit_labels,
         }
     )
 
@@ -389,8 +395,8 @@ def qiskit_to_ionq(circuit, backend, passed_args=None):
     }
     if target == "simulator":
         ionq_json["noise"] = {
-                "model": backend.options.noise_model,
-                "seed": backend.options.sampler_seed,
+            "model": passed_args.get("noise_model", backend.options.noise_model),
+            "seed": backend.options.sampler_seed,
         }
     settings = passed_args.get("job_settings") or None
     if settings is not None:

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -180,7 +180,8 @@ class IonQBackend(Backend):
             ) from ex
 
         if url is None:
-            raise exceptions.IonQCredentialsError("Credentials `url` may not be None!")
+            raise exceptions.IonQCredentialsError(
+                "Credentials `url` may not be None!")
 
         return ionq_client.IonQClient(token, url, self._provider.custom_headers)
 
@@ -356,7 +357,8 @@ class IonQSimulatorBackend(IonQBackend):
                 "description": "IonQ simulator",
                 "basis_gates": GATESET_MAP[gateset],
                 "memory": False,
-                "n_qubits": 32, # Varied based on noise model, but enforced server-side.
+                # Varied based on noise model, but enforced server-side.
+                "n_qubits": 32,
                 "conditional": False,
                 "max_shots": 1,
                 "max_experiments": 1,

--- a/test/helpers/test_qiskit_to_ionq.py
+++ b/test/helpers/test_qiskit_to_ionq.py
@@ -97,7 +97,8 @@ def test_output_map__with_multiple_registers(
     cr1 = ClassicalRegister(2, "cr1")
 
     qc = QuantumCircuit(qr0, qr1, cr0, cr1, name="test_name")
-    qc.measure([qr0[0], qr0[1], qr1[0], qr1[1]], [cr0[0], cr0[1], cr1[0], cr1[1]])
+    qc.measure([qr0[0], qr0[1], qr1[0], qr1[1]],
+               [cr0[0], cr0[1], cr1[0], cr1[1]])
 
     ionq_json = qiskit_to_ionq(
         qc, simulator_backend, passed_args={"shots": 123, "sampler_seed": 42}
@@ -211,7 +212,8 @@ def test_circuit_transpile(simulator_backend):
     Args:
         simulator_backend (IonQSimulatorBackend): A simulator backend fixture.
     """
-    new_backend = simulator_backend.with_name("ionq_simulator", gateset="native")
+    new_backend = simulator_backend.with_name(
+        "ionq_simulator", gateset="native")
     circ = QuantumCircuit(2, 2, name="blame_test")
     circ.cnot(1, 0)
     circ.h(1)
@@ -229,7 +231,8 @@ def test_circuit_incorrect(simulator_backend):
     Args:
         simulator_backend (IonQSimulatorBackend): A simulator backend fixture.
     """
-    native_backend = simulator_backend.with_name("ionq_simulator", gateset="native")
+    native_backend = simulator_backend.with_name(
+        "ionq_simulator", gateset="native")
     circ = QuantumCircuit(2, 2, name="blame_test")
     circ.cnot(1, 0)
     circ.h(1)
@@ -285,7 +288,8 @@ def test_full_native_circuit(simulator_backend):
     Args:
         simulator_backend (IonQSimulatorBackend): A simulator backend fixture.
     """
-    native_backend = simulator_backend.with_name("ionq_simulator", gateset="native")
+    native_backend = simulator_backend.with_name(
+        "ionq_simulator", gateset="native")
     qc = QuantumCircuit(3, name="blame_test")
     qc.append(GPIGate(0.1), [0])
     qc.append(GPI2Gate(0.2), [1])
@@ -293,7 +297,11 @@ def test_full_native_circuit(simulator_backend):
     ionq_json = qiskit_to_ionq(
         qc,
         native_backend,
-        passed_args={"shots": 200, "sampler_seed": 23},
+        passed_args={
+            "noise_model": "harmony",
+            "sampler_seed": 23,
+            "shots": 200
+        },
     )
     expected_metadata_header = {
         "memory_slots": 0,
@@ -311,7 +319,7 @@ def test_full_native_circuit(simulator_backend):
         "target": "simulator",
         "shots": 200,
         "noise": {
-            "model": "ideal",
+            "model": "harmony",
             "seed": None,
         },
         "body": {
@@ -320,7 +328,8 @@ def test_full_native_circuit(simulator_backend):
             "circuit": [
                 {"gate": "gpi", "target": 0, "phase": 0.1},
                 {"gate": "gpi2", "target": 1, "phase": 0.2},
-                {"gate": "ms", "targets": [1, 2], "phases": [0.2, 0.3], "angle": 0.25},
+                {"gate": "ms", "targets": [1, 2],
+                    "phases": [0.2, 0.3], "angle": 0.25},
             ],
         },
     }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short, detailed and understandable for all.
⚠️ If your pull request addresses an open issue, please link to the issue.

✅ I have added tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

😊 Thank you for helping make this project better!
-->

### Summary

Follow [Qiskit convention](https://qiskit.org/documentation/stubs/qiskit_aer.AerSimulator.run.html#qiskit-aer-aersimulator-run) of specifying options in `run(..., **kwargs)`.

### Details and comments

Can invoke with

```python
provider = IonQProvider()
backend = provider.get_backend("ionq_simulator")

job = backend.run(qc, noise_model="ideal")

print(job.get_counts())
```
